### PR TITLE
Add picker for compiler optimization level

### DIFF
--- a/Lowlevel/Sources/Lowlevel/Assembly.swift
+++ b/Lowlevel/Sources/Lowlevel/Assembly.swift
@@ -4,7 +4,7 @@ public final class Assembly {
 
     public init() {}
 
-    public func generateAssembly(fromSwiftCode swiftCode: String) -> String {
+    public func generateAssembly(fromSwiftCode swiftCode: String, optimizationLevel: OptimizationLevel) -> String {
         let tempDirectory = FileManager.default.temporaryDirectory
         let swiftFileURL = tempDirectory.appendingPathComponent("temp.swift")
         let assemblyFileURL = tempDirectory.appendingPathComponent("temp.s")
@@ -14,7 +14,9 @@ public final class Assembly {
             
             let process = processArgument(
                 assemblyFileURL: assemblyFileURL,
-                swiftFileURL: swiftFileURL)
+                swiftFileURL: swiftFileURL,
+                optimizationLevel: optimizationLevel
+            )
             
             let pipe = Pipe()
             process.standardOutput = pipe
@@ -37,12 +39,13 @@ public final class Assembly {
         }
     }
     
-    private func processArgument(assemblyFileURL: URL, swiftFileURL: URL) -> Process {
+    private func processArgument(assemblyFileURL: URL, swiftFileURL: URL, optimizationLevel: OptimizationLevel) -> Process {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/swiftc")
         process.arguments = [
             "-S",
             "-o", assemblyFileURL.path,
+            optimizationLevel.rawValue,
             swiftFileURL.path
         ]
         

--- a/Lowlevel/Sources/Lowlevel/Llvm.swift
+++ b/Lowlevel/Sources/Lowlevel/Llvm.swift
@@ -5,16 +5,18 @@ public final class Llvm {
     
     @Binding private var swiftCode: String
     @Binding private var llvm: String
+    @Binding private var optimizationLevel: OptimizationLevel
     
-    public init(swiftCode: Binding<String>, llvm: Binding<String>) {
+    public init(swiftCode: Binding<String>, llvm: Binding<String>, optimizationLevel: Binding<OptimizationLevel>) {
         self._swiftCode = swiftCode
         self._llvm = llvm
+        self._optimizationLevel = optimizationLevel
     }
     
     public func generateLlvm() {
         let (tempFile, outputFile) = validationFieldSwiftCode()
         
-        let pipe = processArgument(tempFile: tempFile, outputFile: outputFile)
+        let pipe = processArgument(tempFile: tempFile, outputFile: outputFile, optimizationLevel: optimizationLevel)
         
         let errorData = pipe.fileHandleForReading.readDataToEndOfFile()
         let errorOutput = String(data: errorData, encoding: .utf8) ?? ""
@@ -41,10 +43,17 @@ public final class Llvm {
         return (tempFile, outputFile)
     }
     
-    private func processArgument(tempFile: String, outputFile: String) -> Pipe {
+    private func processArgument(tempFile: String, outputFile: String, optimizationLevel: OptimizationLevel) -> Pipe {
         let process = Process()
         process.launchPath = "/usr/bin/env"
-        process.arguments = ["swiftc", "-emit-ir", tempFile, "-o", outputFile]
+        process.arguments = [
+            "swiftc",
+            "-emit-ir",
+            tempFile,
+            "-o",
+            outputFile,
+            optimizationLevel.rawValue
+        ]
         
         let pipe = Pipe()
         let errorPipe = Pipe()

--- a/Lowlevel/Sources/Lowlevel/OptimizationLevel.swift
+++ b/Lowlevel/Sources/Lowlevel/OptimizationLevel.swift
@@ -1,0 +1,6 @@
+public enum OptimizationLevel: String {
+    case balanced = "-O"
+    case none = "-Onone"
+    case size = "-Osize"
+    case unchecked = "-Ounchecked"
+}

--- a/SwiftExplorer/Features/Home/ContentView.swift
+++ b/SwiftExplorer/Features/Home/ContentView.swift
@@ -14,6 +14,7 @@ struct ContentView: View {
     @State private var swiftCode: String = ""
     @State private var llvm: String = ""
     @State private var assemblyCode: String = ""
+    @State private var optimizationLevel: OptimizationLevel = .balanced
     
     @State private var fontSize: Int = 14
     @State private var showAlert = false
@@ -54,32 +55,56 @@ struct ContentView: View {
                         .font(.system(size: 100))
                         .frame(maxWidth: .infinity)
                 }
-                
-                Button{
-                    if !swiftCode.isEmpty {
-                        let llvm = Llvm(swiftCode: $swiftCode, llvm: $llvm)
-                        llvm.generateLlvm()
-                        
-                        assemblyCode = Assembly().generateAssembly(fromSwiftCode: swiftCode)
-                    } else {
-                        showAlert = true
+                VStack {
+                    Button {
+                        if !swiftCode.isEmpty {
+                            let llvm = Llvm(swiftCode: $swiftCode, llvm: $llvm, optimizationLevel: $optimizationLevel)
+                            llvm.generateLlvm()
+                            
+                            assemblyCode = Assembly().generateAssembly(fromSwiftCode: swiftCode, optimizationLevel: optimizationLevel)
+                        } else {
+                            showAlert = true
+                        }
+                    } label: {
+                        Text(L10n.generatedButton)
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color(hex: "#FA7343"))
+                            .bold()
+                            .cornerRadius(8)
                     }
-                } label: {
-                    Text(L10n.generatedButton)
-                        .foregroundColor(.white)
-                        .padding()
-                        .background(Color(hex: "#FA7343"))
-                        .bold()
-                        .cornerRadius(8)
-                }
-                .buttonStyle(PlainButtonStyle())
-                .padding([.leading, .trailing], 20)
-                .alert(isPresented: $showAlert) {
-                    Alert(
-                        title: Text(L10n.warning),
-                        message: Text(L10n.messageEmptyField),
-                        dismissButton: .default(Text(L10n.ok))
-                    )
+                    .buttonStyle(PlainButtonStyle())
+                    .padding([.leading, .trailing], 20)
+                    Picker(selection: $optimizationLevel) {
+                        Text(OptimizationLevel.balanced.rawValue)
+                            .tag(OptimizationLevel.balanced)
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color(hex: "#FA7343"))
+                            .cornerRadius(8)
+                        Text(OptimizationLevel.none.rawValue)
+                            .tag(OptimizationLevel.none)
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color(hex: "#FA7343"))
+                            .cornerRadius(8)
+                        Text(OptimizationLevel.size.rawValue)
+                            .tag(OptimizationLevel.size)
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color(hex: "#FA7343"))
+                            .cornerRadius(8)
+                        Text(OptimizationLevel.unchecked.rawValue)
+                            .tag(OptimizationLevel.unchecked)
+                            .foregroundColor(.white)
+                            .padding()
+                            .background(Color(hex: "#FA7343"))
+                            .cornerRadius(8)
+                    } label: {
+                        EmptyView()
+                    }
+                    .pickerStyle(.segmented)
+                    .padding([.leading, .trailing], 20)
                 }
                 
                 VStack {


### PR DESCRIPTION
The UI addition is minimal and follows some of the existing styling but may need tweaking. Also, the default optimization level is `-O` because that's what I would expect most people to care about when looking at generated code.

Issue #9 