### PR TITLE
Update SwiftLintPlugin to 0.63.1 (was 0.63.0)

### DIFF
--- a/SwiftExplorer.xcodeproj/project.pbxproj
+++ b/SwiftExplorer.xcodeproj/project.pbxproj
@@ -678,7 +678,7 @@
 			repositoryURL = "https://github.com/lukepistrol/SwiftLintPlugin";
 			requirement = {
 				kind = exactVersion;
-				version = 0.63.0;
+				version = 0.63.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
This pull request makes a minor update to the SwiftLint plugin dependency, bumping its version from 0.63.0 to 0.63.1. This ensures the project uses the latest patch release of SwiftLint.

* Updated the SwiftLint plugin version from 0.63.0 to 0.63.1 in `SwiftExplorer.xcodeproj/project.pbxproj`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch-level dependency bump that only affects the SwiftLint build plugin configuration and may slightly change linting behavior in CI/local builds.
> 
> **Overview**
> Updates the `SwiftLintPlugin` Swift Package reference in `SwiftExplorer.xcodeproj/project.pbxproj` from `0.63.0` to `0.63.1` (exact version pin), keeping the project’s SwiftLint build plugin on the latest patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ef0ff70523adc790eea0c7832ac4842b965acdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->