### PR TITLE
refactor: extract project build settings into Settings helper

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -44,22 +44,7 @@ let project = Project(
                 .package(product: "DesignSystem"),
                 .package(product: "Lowlevel")
             ],
-            settings: .settings(
-                base: [
-                    "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-                    "ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME": "AccentColor",
-                    "CODE_SIGN_STYLE": "Automatic",
-                    "COMBINE_HIDPI_IMAGES": "YES",
-                    "CURRENT_PROJECT_VERSION": "1",
-                    "DEVELOPMENT_ASSET_PATHS": "\"SwiftExplorer/Preview Content\"",
-                    "ENABLE_PREVIEWS": "YES",
-                    "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
-                    "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/../Frameworks"],
-                    "MARKETING_VERSION": "2.1.0",
-                    "SWIFT_EMIT_LOC_STRINGS": "YES",
-                    "SWIFT_VERSION": "5.0"
-                ]
-            ),
+            settings: .app,
             launchArguments: [
                 .launchArgument(name: "-FIRAnalyticsDebugEnabled", isEnabled: true),
                 .launchArgument(name: "-FIRDebugEnabled", isEnabled: true)
@@ -77,14 +62,7 @@ let project = Project(
                 .target(name: "SwiftExplorer"),
                 .package(product: "CommonTest")
             ],
-            settings: .settings(
-                base: [
-                    "CODE_SIGN_STYLE": "Automatic",
-                    "CURRENT_PROJECT_VERSION": "1",
-                    "MARKETING_VERSION": "1.0",
-                    "SWIFT_VERSION": "5.0"
-                ]
-            )
+            settings: .tests
         )
     ]
 )

--- a/Tuist/ProjectDescriptionHelpers/Settings.swift
+++ b/Tuist/ProjectDescriptionHelpers/Settings.swift
@@ -1,0 +1,29 @@
+import ProjectDescription
+
+public extension Settings {
+    static let app = Settings.settings(
+        base: [
+            "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
+            "ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME": "AccentColor",
+            "CODE_SIGN_STYLE": "Automatic",
+            "COMBINE_HIDPI_IMAGES": "YES",
+            "CURRENT_PROJECT_VERSION": "1",
+            "DEVELOPMENT_ASSET_PATHS": "\"SwiftExplorer/Preview Content\"",
+            "ENABLE_PREVIEWS": "YES",
+            "ENABLE_USER_SCRIPT_SANDBOXING": "NO",
+            "LD_RUNPATH_SEARCH_PATHS": ["$(inherited)", "@executable_path/../Frameworks"],
+            "MARKETING_VERSION": "2.1.0",
+            "SWIFT_EMIT_LOC_STRINGS": "YES",
+            "SWIFT_VERSION": "5.0"
+        ]
+    )
+
+    static let tests = Settings.settings(
+        base: [
+            "CODE_SIGN_STYLE": "Automatic",
+            "CURRENT_PROJECT_VERSION": "1",
+            "MARKETING_VERSION": "1.0",
+            "SWIFT_VERSION": "5.0"
+        ]
+    )
+}


### PR DESCRIPTION
## ✨ Summary

- extract inline app target settings dictionary into `Settings.app` in `Tuist/ProjectDescriptionHelpers/Settings.swift`
- extract inline tests target settings dictionary into `Settings.tests`
- update `Project.swift` to reference the new `Settings.app` / `Settings.tests` helpers

## 🔧 Type of Change

- [ ] ✨ Enhancement
- [ ] 🐞 Bug fix
- [ ] 🔐 Security fix
- [ ] 💥 Breaking change
- [ ] 🚀 New feature
- [ ] 📦 New release
- [ ] 📚 Documentation
- [x] ♻️ Refactor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tuist-only refactor with settings values copied unchanged; risk is limited to a mis-copy during extraction affecting builds.
> 
> **Overview**
> Moves duplicated Tuist **build settings** out of `Project.swift` into shared helpers on `Settings` in `Tuist/ProjectDescriptionHelpers/Settings.swift`.
> 
> The **SwiftExplorer** app target now uses `settings: .app` and **SwiftExplorerTests** uses `settings: .tests`, with the same keys and values as the previous inline dictionaries (signing, versions, Swift/previews flags, etc.). No intended change to generated Xcode build configuration—only structure and reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7df3982b28d2eb6d1e740ac05a5fc31c4fb003b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->